### PR TITLE
Add php 7.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 phpunit.xml
 vendor
+.idea
+build

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "homepage": "https://sqids.org/php",
     "require": {
-        "php": "^8.1"
+        "php": "^7.1|^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5|^11.2"
+        "phpunit/phpunit": "^7.5|^10.5|^11.2"
     },
     "suggest": {
         "ext-bcmath": "Required to use BC Math arbitrary precision mathematics (*).",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" cacheResult="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd">
-  <coverage/>
-  <testsuites>
-    <testsuite name="Test Suite">
-      <directory suffix="Test.php">./tests</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
+<phpunit bootstrap="vendor/autoload.php" cacheResult="false" colors="true">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <log type="coverage-html" target="build/coverage" lowUpperBound="50" highLowerBound="90"/>
+    </logging>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Sqids.php
+++ b/src/Sqids.php
@@ -19,9 +19,9 @@ use RuntimeException;
 
 class Sqids implements SqidsInterface
 {
-    final public const DEFAULT_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    final public const DEFAULT_MIN_LENGTH = 0;
-    final public const DEFAULT_BLOCKLIST = [
+    public const DEFAULT_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    public const DEFAULT_MIN_LENGTH = 0;
+    public const DEFAULT_BLOCKLIST = [
         "0rgasm",
         "1d10t",
         "1d1ot",
@@ -584,14 +584,20 @@ class Sqids implements SqidsInterface
         "zoccola",
     ];
 
-    protected MathInterface $math;
+    protected $math;
+    protected $alphabet = self::DEFAULT_ALPHABET;
+    protected $minLength = self::DEFAULT_MIN_LENGTH;
+    protected $blocklist = self::DEFAULT_BLOCKLIST;
 
     /** @throws \InvalidArgumentException */
     public function __construct(
-        protected string $alphabet = self::DEFAULT_ALPHABET,
-        protected int $minLength = self::DEFAULT_MIN_LENGTH,
-        protected array $blocklist = self::DEFAULT_BLOCKLIST,
+        string $alphabet = self::DEFAULT_ALPHABET,
+        int $minLength = self::DEFAULT_MIN_LENGTH,
+        array $blocklist = self::DEFAULT_BLOCKLIST
     ) {
+        $this->blocklist = $blocklist;
+        $this->minLength = $minLength;
+        $this->alphabet = $alphabet;
         $this->math = $this->getMathExtension();
 
         if ($alphabet == '') {
@@ -617,7 +623,7 @@ class Sqids implements SqidsInterface
             $minLength > $minLengthLimit
         ) {
             throw new InvalidArgumentException(
-                'Minimum length has to be between 0 and ' . $minLengthLimit,
+                'Minimum length has to be between 0 and ' . $minLengthLimit
             );
         }
 
@@ -627,7 +633,9 @@ class Sqids implements SqidsInterface
             if (strlen((string) $word) >= 3) {
                 $wordLowercased = strtolower($word);
                 $wordChars = str_split((string) $wordLowercased);
-                $intersection = array_filter($wordChars, fn($c) => in_array($c, $alphabetChars));
+                $intersection = array_filter($wordChars, function ($c) use ($alphabetChars) {
+                    return in_array($c, $alphabetChars);
+                });
                 if (count($intersection) == count($wordChars)) {
                     $filteredBlocklist[] = strtolower((string) $wordLowercased);
                 }
@@ -655,10 +663,12 @@ class Sqids implements SqidsInterface
             return '';
         }
 
-        $inRangeNumbers = array_filter($numbers, fn($n) => $n >= 0 && $n <= self::maxValue());
+        $inRangeNumbers = array_filter($numbers, function ($n) {
+            return $n >= 0 && $n <= self::maxValue();
+        });
         if (count($inRangeNumbers) != count($numbers)) {
             throw new InvalidArgumentException(
-                'Encoding supports numbers between 0 and ' . self::maxValue(),
+                'Encoding supports numbers between 0 and ' . self::maxValue()
             );
         }
 
@@ -819,10 +829,10 @@ class Sqids implements SqidsInterface
                         return true;
                     }
                 } elseif (preg_match('/~[0-9]+~/', (string) $word)) {
-                    if (str_starts_with($id, (string) $word) || strrpos($id, (string) $word) === strlen($id) - strlen((string) $word)) {
+                    if (strpos($id, (string) $word) === 0 || strrpos($id, (string) $word) === strlen($id) - strlen((string) $word)) {
                         return true;
                     }
-                } elseif (str_contains($id, (string) $word)) {
+                } elseif (strpos($id, (string) $word) !== false) {
                     return true;
                 }
             }

--- a/tests/SqidsBlocklistTest.php
+++ b/tests/SqidsBlocklistTest.php
@@ -59,8 +59,8 @@ class SqidsBlocklistTest extends TestCase
             '7tE6', // result of 4th encoding is `7tE6jdAHLe`, let's block the prefix
         ]);
 
-        $this->assertSame('1aYeB7bRUt', $sqids->encode([1_000_000, 2_000_000]));
-        $this->assertSame([1_000_000, 2_000_000], $sqids->decode('1aYeB7bRUt'));
+        $this->assertSame('1aYeB7bRUt', $sqids->encode([1000000, 2000000]));
+        $this->assertSame([1000000, 2000000], $sqids->decode('1aYeB7bRUt'));
     }
 
     public function testDecodingBlocklistWordsShouldStillWork()

--- a/tests/SqidsMinLengthTest.php
+++ b/tests/SqidsMinLengthTest.php
@@ -90,8 +90,8 @@ class SqidsMinLengthTest extends TestCase
                 [0, 0, 0, 0, 0],
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                 [100, 200, 300],
-                [1_000, 2_000, 3_000],
-                [1_000_000],
+                [1000, 2000, 3000],
+                [1000000],
                 [PHP_INT_MAX],
             ] as $numbers) {
                 $sqids = new Sqids(Sqids::DEFAULT_ALPHABET, $minLength);


### PR DESCRIPTION
This PR introduces changes to ensure compatibility with PHP 7.1.

The modifications include:
- Adjusted syntax and features to work with PHP 7.1.
- Updated `composer.json` to allow PHP 7.1.
- Ensured all tests pass on PHP 7.1.

**Proposal:**
I suggest creating a new branch (`php-71`) for support of PHP 7.1.

**Note:**
I understand that PHP 7.1 is no longer recommended for use, and such projects should be upgraded to a supported PHP version. I am working on a legacy PHP project where I need to implement the Sqids logic to align with services written in other languages. Unfortunately, upgrading the PHP version is not an option at the moment, so I have chosen this approach.